### PR TITLE
Overhaul map completion

### DIFF
--- a/src/main/java/com/robertx22/library_of_exile/dimension/structure/dungeon/DungeonRoomPlacer.java
+++ b/src/main/java/com/robertx22/library_of_exile/dimension/structure/dungeon/DungeonRoomPlacer.java
@@ -1,6 +1,7 @@
 package com.robertx22.library_of_exile.dimension.structure.dungeon;
 
 import com.robertx22.library_of_exile.dimension.structure.MapStructure;
+import com.robertx22.library_of_exile.events.base.ExileEvents;
 import com.robertx22.library_of_exile.main.ExileLog;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
@@ -9,9 +10,13 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.ServerLevelAccessor;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+
+import java.util.List;
 
 public class DungeonRoomPlacer {
 
@@ -22,6 +27,26 @@ public class DungeonRoomPlacer {
         StructurePlaceSettings settings = new StructurePlaceSettings().setMirror(Mirror.NONE)
                 .setRotation(rota)
                 .setIgnoreEntities(false);
+        List<StructureTemplate.StructureBlockInfo> commandBlocks = template.filterBlocks(BlockPos.ZERO, new StructurePlaceSettings(), Blocks.COMMAND_BLOCK, true);
+        List<StructureTemplate.StructureBlockInfo> structureBlocks = template.filterBlocks(BlockPos.ZERO, new StructurePlaceSettings(), Blocks.STRUCTURE_BLOCK, true);
+
+        final BlockPos finalPosition = position;
+
+        commandBlocks
+        .forEach((block) -> {
+            BlockPos worldPos = finalPosition.offset(block.pos());
+
+            var event = new ExileEvents.DungeonDataBlockPlaced(world, worldPos, block, id);
+            ExileEvents.DUNGEON_DATA_BLOCK_PLACED.callEvents(event);
+        });
+
+        structureBlocks
+        .forEach((block) -> {
+            BlockPos worldPos = finalPosition.offset(block.pos());
+
+            var event = new ExileEvents.DungeonDataBlockPlaced(world, worldPos, block, id);
+            ExileEvents.DUNGEON_DATA_BLOCK_PLACED.callEvents(event);
+        });
 
         settings.setBoundingBox(settings.getBoundingBox());
 

--- a/src/main/java/com/robertx22/library_of_exile/events/base/ExileEvents.java
+++ b/src/main/java/com/robertx22/library_of_exile/events/base/ExileEvents.java
@@ -11,6 +11,7 @@ import com.robertx22.library_of_exile.registry.ExileRegistryEvent;
 import com.robertx22.library_of_exile.registry.ExileRegistryType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.damagesource.DamageSource;
@@ -19,7 +20,9 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.level.storage.loot.LootParams;
 
 import java.util.ArrayList;
@@ -52,6 +55,7 @@ public class ExileEvents {
     public static ExileEventCaller<OnProcessMapDataBlock> PROCESS_DATA_BLOCK = new ExileEventCaller<>();
     public static ExileEventCaller<OnProcessChunkData> PROCESS_CHUNK_DATA = new ExileEventCaller<>();
     public static ExileEventCaller<GrabLibMapData> GRAB_LIB_MAP_DATA = new ExileEventCaller<>();
+    public static ExileEventCaller<DungeonDataBlockPlaced> DUNGEON_DATA_BLOCK_PLACED = new ExileEventCaller<>();
 
     // todo maybe i can add adapters to this and save stuff like registry strings into wrapper classes??
 
@@ -80,6 +84,19 @@ public class ExileEvents {
 
     }
 
+    public static class DungeonDataBlockPlaced extends ExileEvent {
+        public LevelAccessor levelAccessor;
+        public BlockPos pos;
+        public StructureTemplate.StructureBlockInfo blockInfo;
+        public ResourceLocation structureId;
+
+        public DungeonDataBlockPlaced(LevelAccessor levelAccessor, BlockPos pos, StructureTemplate.StructureBlockInfo blockInfo, ResourceLocation structureId) {
+            this.levelAccessor = levelAccessor;
+            this.pos = pos;
+            this.blockInfo = blockInfo;
+            this.structureId = structureId;
+        }
+    }
 
     public static class GrabLibMapData extends ExileEvent {
         public Level level;


### PR DESCRIPTION
Add a new `DungeonCommandBlockPlaced` event we can hook into inside `dungeon_realm`, and use it to effectively count command blocks inside maps, to ultimately give us proper bounds for the number of mobs summoned so we can track completion-percentage per map instead of trying to track mobs per room.